### PR TITLE
Handle git command error and print its message

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,6 @@ const token = tokenJson.token;
   for (let git of pgits) {
     const repoName = git.substring(19, git.length - 4)
     console.log(`Cloning ${repoName}`)
-    const stdout = await cmdAsync(`git clone ${git} backup/${repoName}`)
+    const stdout = await cmdAsync(`git clone ${git} backup/${repoName}`).catch(console.log)
   }
 })()


### PR DESCRIPTION
Handle error that may occur when trying to execute the git clone command. There may be multiple reasons for that.
Without catching the error the program will stop before trying to download the rest of the repository.  

![<img src="(https://user-images.githubusercontent.com/15923605/74486702-d9517080-4ebd-11ea-8316-7d329adbf4bf.jpg" width=200 />](https://user-images.githubusercontent.com/15923605/74486702-d9517080-4ebd-11ea-8316-7d329adbf4bf.jpg)
