### PR TITLE
Add Support for private instances of gitlab

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,15 +28,25 @@ const cliProgress = require('cli-progress');
       type: 'boolean',
       description: 'Enable verbose output'
     })
+    .option('url', {
+      alias: 'u',
+      type: 'string',
+      description: 'Specify Gitlab instance URL'
+    })
     .help(true)
     .argv
 
+  const baseUrl = argv.url || 'https://gitlab.com':
+  if(argv.verbose){
+    console.log(`Set gitlab url to ${baseUrl}`)
+  }
+  console .log()
   if (!argv.token) {
-    console.log('Please pass your gitlab token using the --token flag,\nGet your token at https://gitlab.com/profile/personal_access_tokens\n\npass --help for full help\n\n')
+    console.log(`Please pass your gitlab token using the --token flag,\nGet your token at ${baseUrl}/profile/personal_access_tokens\n\npass --help for full help\n\n`)
     process.exit(1)
   }
 
-  let groups = await rp.get('https://www.gitlab.com/api/v4/groups?per_page=999', {
+  let groups = await rp.get(`${baseUrl}/api/v4/groups?per_page=999`, {
     json: true,
     qs: {
       simple: true,
@@ -51,7 +61,7 @@ const cliProgress = require('cli-progress');
   let gids = _.map(groups, 'id')
   let pgits = []
   for (let gid of gids) {
-    let projects = await rp.get(`https://www.gitlab.com/api/v4/groups/${gid}/projects?per_page=999`, {
+    let projects = await rp.get(`${baseUrl}/api/v4/groups/${gid}/projects?per_page=999`, {
       json: true,
       qs: {
         simple: true,

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const cliProgress = require('cli-progress');
     .help(true)
     .argv
 
-  const baseUrl = argv.url || 'https://gitlab.com':
+  const baseUrl = argv.url || 'https://gitlab.com';
   if(argv.verbose){
     console.log(`Set gitlab url to ${baseUrl}`)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "gitlab_backup_util",
-  "version": "1.0.2",
+  "name": "gitlab-backup-util",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab-backup-util",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A small utility to backup or clone all projects you have on gitlab.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
by using a url argument, we can now backup from any gitlab instance using a very simple api