### PR TITLE
Add ssh clone method

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,16 @@ You never know when international laws change and you loose access to your repos
 
 ## How to Backup 
 
+### Backup using http (default)
+
 ```javascript
 npm install -g gitlab-backup-util
 gitlab-backup-util -t 'your-gl-token-here'
+```
+
+### Backup using ssh
+```javascript
+gitlab-backup-util -t 'your-gl-token-here' -m ssh
 ```
 
 #### Future Scope

--- a/index.js
+++ b/index.js
@@ -33,6 +33,11 @@ const cliProgress = require('cli-progress');
       type: 'string',
       description: 'Specify Gitlab instance URL'
     })
+    .option('method', {
+      alias: 'm',
+      type: 'string',
+      description: 'Specify clone method (default is http)'
+    })
     .help(true)
     .argv
 
@@ -45,7 +50,10 @@ const cliProgress = require('cli-progress');
     console.log(`Please pass your gitlab token using the --token flag,\nGet your token at ${baseUrl}/profile/personal_access_tokens\n\npass --help for full help\n\n`)
     process.exit(1)
   }
+  console.log(argv.method)
 
+  const method = argv.method == 'ssh' ? 'ssh_url_to_repo' : 'http_url_to_repo'
+  console.log(method)
   let groups = await rp.get(`${baseUrl}/api/v4/groups?per_page=999`, {
     json: true,
     qs: {
@@ -70,7 +78,7 @@ const cliProgress = require('cli-progress');
         'PRIVATE-TOKEN': argv.token
       }
     })
-    let ps = _.map(projects, 'http_url_to_repo')
+    let ps = _.map(projects, method)
     for (let p of ps) {
       console.log(`Got project ${p} of ${gid}`)
       pgits.push(p)

--- a/index.js
+++ b/index.js
@@ -50,10 +50,8 @@ const cliProgress = require('cli-progress');
     console.log(`Please pass your gitlab token using the --token flag,\nGet your token at ${baseUrl}/profile/personal_access_tokens\n\npass --help for full help\n\n`)
     process.exit(1)
   }
-  console.log(argv.method)
 
   const method = argv.method == 'ssh' ? 'ssh_url_to_repo' : 'http_url_to_repo'
-  console.log(method)
   let groups = await rp.get(`${baseUrl}/api/v4/groups?per_page=999`, {
     json: true,
     qs: {


### PR DESCRIPTION
Add clone method. 

Clone methods:

- http (default)
- ssh

Update README.md with new clone example