### PR TITLE
Allow usage of path with spaces in --output flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,13 +133,13 @@ const cliProgress = require('cli-progress');
         console.error(`Path ${repoPath} exist and not a directory. Skipped.`)
       } else {
         console.log(`Pulling ${repoName}`)
-        const stdout = await cmdAsync(`git -C ${repoPath} pull`).catch(
+        const stdout = await cmdAsync(`git -C "${repoPath}" pull`).catch(
           console.log
         )
       }
     } else {
       console.log(`Cloning ${repoName}`)
-      const stdout = await cmdAsync(`git clone ${repo} ${repoPath}`).catch(
+      const stdout = await cmdAsync(`git clone ${repo} "${repoPath}"`).catch(
         console.log
       )
     }


### PR DESCRIPTION
I had problems with paths like 

node "/media/yyyyyy/Seagate Expansion Drive/07 Git/index.js" -t "YYYYYYYYYYYYYYYY" -m ssh -o /media/yyyyy/Seagate\ Expansion\ Drive/07\ Git/gitlab-backup

So I added quotes for git pull and clone